### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon-Connect-Copy User Guide
 
-The Amazon-Connect-Copy script (v1.2.2) copies components from the source Amazon Connect instance
+The Amazon-Connect-Copy script (v1.3) copies components from the source Amazon Connect instance
 to the target instance safely, fixing all internal references.
 
 You may use Amazon-Connect-Copy to deploy an Amazon Connect instance across environments

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ their corresponding components in the new instance, including:
 - Lex bots (Classic) (pre-deployed)
 - Prompts (pre-uploaded)
 - Hours of operations
-- Queues
+- Queues (STANDARD type only)
 - Routing profiles
 - Contact flow modules
 - Contact flows
@@ -30,8 +30,9 @@ other contact centres that may happen to be using the same target instance):
   - Inbound Contact flow/IVR mappings
   - Outbound caller ID number for queues
 - Quick connects
-- Settings for existing queues
-  - Note: Settings for new queues will still be copied
+- Agent queues
+- Settings for existing standard queues
+  - Note: Settings for new standard queues will still be copied
 - Historical metrics and reports
 - Contact Trace Records (CTRs)
 - Custom vocabularies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon-Connect-Copy User Guide
 
-The Amazon-Connect-Copy script (v1.3) copies components from the source Amazon Connect instance
+The Amazon-Connect-Copy script (v1.3.1) copies components from the source Amazon Connect instance
 to the target instance safely, fixing all internal references.
 
 You may use Amazon-Connect-Copy to deploy an Amazon Connect instance across environments

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon-Connect-Copy User Guide
 
-The Amazon-Connect-Copy script (v1.3.1) copies components from the source Amazon Connect instance
+The Amazon-Connect-Copy script (v1.3.2) copies components from the source Amazon Connect instance
 to the target instance safely, fixing all internal references.
 
 You may use Amazon-Connect-Copy to deploy an Amazon Connect instance across environments
@@ -53,6 +53,7 @@ A note to developers: To contribute, please read [CONTRIBUTING.md](./CONTRIBUTIN
 - Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
   - Recommend installing the latest version of AWS CLI.
 - Install [jq](https://stedolan.github.io/jq/) (if not already installed on your platform).
+  - Require `jq` version 1.6 or higher.
 - Copy `bin/*` to your Shell search path (e.g., `cp bin/* /usr/local/bin/`).
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Example:
 
 ## Useful Tips
 
-- This script has been tested with AWS CLI 2.4.1, which supports the latest
+- This script has been tested with AWS CLI 2.8.6, which supports the latest
   Amazon Connect features, including Contact Flow Modules.
   (Even your instances may not be using all latest Amazon Connect features,
   the script will check them and therefore require the latest AWS CLI.)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+- Version 1.3.1
+  - Limit queue copying to STANDARD type only
+
 - Version 1.3
   - Fix an error when a routing profile has no queues
   - Fix reference cross-reference between contact flows and modules

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+- Version 1.3
+  - Fix an error when a routing profile has no queues
+  - Fix reference cross-reference between contact flows and modules
+
 - Version 1.2.2
   - Delete NumberOfAssociatedQueues and NumberOfAssociatedUsers from AWS CLI describe-routing-profile output
   - Error handle iconv in connect_save

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+- Version 1.3.2
+  - Fix QueueName select in RoutingProfileQueueConfigSummaryList
+  - Remove routing_profile_to_ignore from connect_diff
+  - Explicit with `.` in `jq -s '.'` (instead of just `jq -s`) in connect_copy
+
 - Version 1.3.1
   - Fix unpublished contact flow error
   - Limit queue copying to STANDARD type only

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,9 @@
 # Release Notes
 
 - Version 1.3.1
+  - Fix unpublished contact flow error
   - Limit queue copying to STANDARD type only
+  - Update doc
 
 - Version 1.3
   - Fix an error when a routing profile has no queues

--- a/bin/connect_copy
+++ b/bin/connect_copy
@@ -5,7 +5,7 @@
 # Copy Amazon Connect instance A to instance B safely
 #
 
-VERSION=1.3
+VERSION=1.3.1
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD
@@ -482,6 +482,7 @@ EOD
         # Update instance B queues
         aws_connect list-queues \
             --instance-id $instance_id_b \
+            --queue-types "STANDARD" \
             > $TEMPFILE || error $LINENO
         cat $TEMPFILE |
         jq -r ".QueueSummaryList[] | select(.QueueType != \"AGENT\")" > "$instance_alias_dir_b/queues.json"

--- a/bin/connect_copy
+++ b/bin/connect_copy
@@ -5,7 +5,7 @@
 # Copy Amazon Connect instance A to instance B safely
 #
 
-VERSION=1.3.1
+VERSION=1.3.2
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD
@@ -698,7 +698,7 @@ else
 
             cat "$instance_alias_dir_b/$routing_json" |
             jq -r ".RoutingProfile.MediaConcurrencies[] | select(.Concurrency != 0)" |
-            jq -s > "$helper/routingConcurrency_$routing_name.json"
+            jq -s "." > "$helper/routingConcurrency_$routing_name.json"
 
             cat <<EOD >> "$helper_log"
 
@@ -757,9 +757,9 @@ EOD
                     # cat "$instance_alias_dir_a/routingQs_$routing_name.json" |
                     #     jq -r ".RoutingProfileQueueConfigSummaryList[] | select(.QueueName == \"${q_name//\"/\\\"}\") | { QueueReference: { QueueId, Channel }, Priority, Delay }" >> $TEMP1
                     sed -e's/\\"/%22/g' "$instance_alias_dir_a/routingQs_$routing_name.json" |
-                        jq -r ".RoutingProfileQueueConfigSummaryList[] | select(.QueueName == \"${q_name//\"/%22}}\") | { QueueReference: { QueueId, Channel }, Priority, Delay }" >> $TEMP1
+                        jq -r ".RoutingProfileQueueConfigSummaryList[] | select(.QueueName == \"${q_name//\"/%22}\") | { QueueReference: { QueueId, Channel }, Priority, Delay }" >> $TEMP1
                 done
-                cat $TEMP1 | sed -f "$helper_sed" | jq -s > "$helper/routingQueueConfig_$routing_name.json"
+                cat $TEMP1 | sed -f "$helper_sed" | jq -s "." > "$helper/routingQueueConfig_$routing_name.json"
 
                 cat <<EOD >> "$helper_log"
 

--- a/bin/connect_copy
+++ b/bin/connect_copy
@@ -5,7 +5,7 @@
 # Copy Amazon Connect instance A to instance B safely
 #
 
-VERSION=1.2.2
+VERSION=1.3
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD
@@ -134,12 +134,13 @@ TEMPFILE=$(mktemp)
 TEMPERR=${TEMPFILE}_err
 TEMPNEW=${TEMPFILE}_new
 TEMPOLD=${TEMPFILE}_old
+TEMPMOD=${TEMPFILE}_mod
 TEMPA=${TEMPFILE}_A
 TEMPB=${TEMPFILE}_B
 TEMP1=${TEMPFILE}_1
 TEMP2=${TEMPFILE}_2
 trap 'rm -r -- $TEMPFILE $TEMPERR $TEMPNEW $TEMPOLD $TEMPA $TEMPB $TEMP1 $TEMP2' EXIT
-touch $TEMPFILE $TEMPERR $TEMPNEW $TEMPOLD $TEMPA $TEMPB $TEMP1 $TEMP2
+touch $TEMPFILE $TEMPERR $TEMPNEW $TEMPOLD $TEMPMOD $TEMPA $TEMPB $TEMP1 $TEMP2
 
 actionLead="# Action -"
 dryrun=
@@ -526,31 +527,35 @@ gen_helper_routing_new() {
     routing_name=$1
     out_file="$helper/routingNew_$routing_name.json"
     rpqr_file=$(gen_helper_rpqr "$routing_name")
+    qconfs=
+    if [ -s $rpqr_file ]; then
+        qconfs=", QueueConfigs: \$rpqc"
+    fi
     cat "$instance_alias_dir_a/routing_$routing_name.json" |
     jq --arg iid $instance_id_b \
         --slurpfile rpqc "$rpqr_file" \
         ".RoutingProfile |
         del(.RoutingProfileId, .RoutingProfileArn) |
-        . + { InstanceId: \$iid, QueueConfigs: \$rpqc } |
+        . + { InstanceId: \$iid$qconfs } |
         del(.MediaConcurrencies[] | select(.Concurrency == 0))" |
     sed -f "$helper_sed" > "$out_file"
     rm "$rpqr_file"
     echo "$out_file"
 }
 
-gen_helper_routing_old() {
-    routing_name=$1
-    out_file="$helper/routingOld_$routing_name.json"
-    rpqr_file=$(gen_helper_rpqr "$routing_name")
-    cat "$instance_alias_dir_b/routing_$routing_name.json" |
-    jq --arg iid $instance_id_b \
-        --slurpfile rpqc "$rpqr_file" \
-        ".RoutingProfile |
-        { InstanceId, RoutingProfileId, QueueConfigs: \$rpqc }" |
-    sed -f "$helper_sed" > "$out_file"
-    rm "$rpqr_file"
-    echo "$out_file"
-}
+# gen_helper_routing_old() {
+#     routing_name=$1
+#     out_file="$helper/routingOld_$routing_name.json"
+#     rpqr_file=$(gen_helper_rpqr "$routing_name")
+#     cat "$instance_alias_dir_b/routing_$routing_name.json" |
+#     jq --arg iid $instance_id_b \
+#         --slurpfile rpqc "$rpqr_file" \
+#         ".RoutingProfile |
+#         { InstanceId, RoutingProfileId, QueueConfigs: \$rpqc }" |
+#     sed -f "$helper_sed" > "$out_file"
+#     rm "$rpqr_file"
+#     echo "$out_file"
+# }
 
 cat <<EOD
 
@@ -796,7 +801,12 @@ fi
 
 ############################################################
 #
-# Contact Flow Modules
+# Contact Flow Modules Creation
+# TODO:
+#   - Use $helper/module_template.json as a template to create new contact flows
+#
+# Note: Must create all flow modules and flows from an empty template first
+# such that references can be resolved in updates
 #
 
 cat <<EOD
@@ -806,7 +816,8 @@ Contact Flow Modules Creation
 EOD
 
 # Preload as $helper_old may change
-egrep "^module_$contact_flow_prefix_encoded" "$helper_old" > $TEMPOLD
+# Use TEMPMOD instead of TEMPOLD to carry over to module update
+egrep "^module_$contact_flow_prefix_encoded" "$helper_old" > $TEMPMOD
 # Create what is in $helper_new
 egrep "^module_$contact_flow_prefix_encoded" "$helper_new" > $TEMPNEW
 if [ ! -s $TEMPNEW ]; then
@@ -828,12 +839,12 @@ else
         out_file="$helper/output_$module_json"
 
         # Contact Flow Module template file
-        # module_template_file=$helper/module_template.json
+        module_template_file=$helper/module_template.json
 
-        cat "$instance_alias_dir_a/$module_json" |
-        sed -f "$helper_sed" |
-        sub_lex_bot \
-        > "$helper/$module_json"
+        # cat "$instance_alias_dir_a/$module_json" |
+        # sed -f "$helper_sed" |
+        # sub_lex_bot \
+        # > "$helper/$module_json"
 
         cat <<EOD >> "$helper_log"
 
@@ -850,7 +861,7 @@ EOD
 aws connect create-contact-flow-module \
 --instance-id $instance_id_b \
 --name "${module_name_decoded//\"/\\\"}" \
---content "file://$helper/$module_json" \
+--content "file://$module_template_file" \
 > "$out_file"
 EOD
             # rm "$helper/$module_json"
@@ -860,12 +871,12 @@ EOD
         aws_connect create-contact-flow-module \
             --instance-id $instance_id_b \
             --name "${module_name_decoded//\"/\\\"}" \
-            --content "file://$helper/$module_json" \
+            --content "file://$module_template_file" \
             > "$out_file" || error $LINENO
         module_id_b=$(jq -r ".Id" "$out_file" | dos2unix)
 
-        # All flows will be updated with content
-        # echo "$module_json" >> $TEMPOLD
+        # All flow modules will be updated with content
+        echo "$module_json" >> $TEMPMOD
 
         aws_connect describe-contact-flow-module \
             --instance-id $instance_id_b \
@@ -898,81 +909,9 @@ EOD
 fi
 
 
-cat <<EOD
-
-Contact Flow Modules Update
----------------------------
-EOD
-
-if [ ! -s $TEMPOLD ]; then
-    echo "No contact flow modules to update"
-else
-    num_modules=$(echo $(cat $TEMPOLD | wc -l))
-    echo -e "\nChecking $num_modules contact flow modules$contact_flow_prefix_text for an update"
-    ii=0
-    sort $TEMPOLD |
-    while read module_json; do
-        ii=$[ii+1]
-        echo -n "$ii. $module_json ... "
-        module_name=${module_json#module_}
-        module_name=${module_name%.json}
-        module_name_decoded=$(path_decode "$module_name")
-
-        # module_id_b=$(jq -r "select(.Name == \"${module_name_decoded//\"/\\\"}\") | .Id" "$instance_alias_dir_b/modules.json")
-        module_id_b=$(sed -e's/\\"/%22/g' "$instance_alias_dir_b/modules.json" | jq -r "select(.Name == \"${module_name_decoded//\"/%22}\") | .Id" | dos2unix)
-
-        cat "$instance_alias_dir_a/$module_json" > $TEMPA
-        cat "$instance_alias_dir_b/$module_json" > $TEMPB
-        df=$(diff_files); echo $df; test "$df" == "same" && continue
-
-        cat "$instance_alias_dir_a/$module_json" |
-        sed -f "$helper_sed" |
-        sub_lex_bot \
-        > "$helper/$module_json"
-
-        cat <<EOD >> "$helper_log"
-
-$actionLead Update contact flow module: $module_name_decoded
-EOD
-        if [ -n "$dryrun" ]; then
-            cat <<EOD
-Dry-update contact flow module
---instance-id $instance_id_b
---contact-flow-module-id $module_id_b
-
-EOD
-            cat <<EOD >> "$helper_log"
-aws connect update-contact-flow-module-content \
---instance-id $instance_id_b \
---contact-flow-module-id $module_id_b \
---content "file://$helper/$module_json" \
-> "$helper/output_content_$module_json"
-EOD
-            # rm "$helper/$module_json"
-            continue
-        fi
-
-        aws_connect update-contact-flow-module-content \
-            --instance-id $instance_id_b \
-            --contact-flow-module-id $module_id_b \
-            --content "file://$helper/$module_json" \
-            > "$helper/output_content_$module_json" || error $LINENO
-
-        aws_connect describe-contact-flow-module \
-            --instance-id $instance_id_b \
-            --contact-flow-module-id $module_id_b \
-            > $TEMPFILE || error $LINENO
-        cat $TEMPFILE |
-        jq -r '.ContactFlowModule.Content' > "$instance_alias_dir_b/$module_json"
-    done
-    test $? -eq 0 || error
-fi
-
-
-
 ############################################################
 #
-# Contact Flows
+# Contact Flows Creation
 #
 # TODO:
 #   - Use $helper/flow_template.json as a template to create new contact flows
@@ -1093,6 +1032,87 @@ EOD
     fi
 fi
 
+
+############################################################
+#
+# Contact Flow Modules Update
+#
+
+cat <<EOD
+
+Contact Flow Modules Update
+---------------------------
+EOD
+
+if [ ! -s $TEMPMOD ]; then
+    echo "No contact flow modules to update"
+else
+    num_modules=$(echo $(cat $TEMPMOD | wc -l))
+    echo -e "\nChecking $num_modules contact flow modules$contact_flow_prefix_text for an update"
+    ii=0
+    sort $TEMPMOD |
+    while read module_json; do
+        ii=$[ii+1]
+        echo -n "$ii. $module_json ... "
+        module_name=${module_json#module_}
+        module_name=${module_name%.json}
+        module_name_decoded=$(path_decode "$module_name")
+
+        # module_id_b=$(jq -r "select(.Name == \"${module_name_decoded//\"/\\\"}\") | .Id" "$instance_alias_dir_b/modules.json")
+        module_id_b=$(sed -e's/\\"/%22/g' "$instance_alias_dir_b/modules.json" | jq -r "select(.Name == \"${module_name_decoded//\"/%22}\") | .Id" | dos2unix)
+
+        cat "$instance_alias_dir_a/$module_json" > $TEMPA
+        cat "$instance_alias_dir_b/$module_json" > $TEMPB
+        df=$(diff_files); echo $df; test "$df" == "same" && continue
+
+        cat "$instance_alias_dir_a/$module_json" |
+        sed -f "$helper_sed" |
+        sub_lex_bot \
+        > "$helper/$module_json"
+
+        cat <<EOD >> "$helper_log"
+
+$actionLead Update contact flow module: $module_name_decoded
+EOD
+        if [ -n "$dryrun" ]; then
+            cat <<EOD
+Dry-update contact flow module
+--instance-id $instance_id_b
+--contact-flow-module-id $module_id_b
+
+EOD
+            cat <<EOD >> "$helper_log"
+aws connect update-contact-flow-module-content \
+--instance-id $instance_id_b \
+--contact-flow-module-id $module_id_b \
+--content "file://$helper/$module_json" \
+> "$helper/output_content_$module_json"
+EOD
+            # rm "$helper/$module_json"
+            continue
+        fi
+
+        aws_connect update-contact-flow-module-content \
+            --instance-id $instance_id_b \
+            --contact-flow-module-id $module_id_b \
+            --content "file://$helper/$module_json" \
+            > "$helper/output_content_$module_json" || error $LINENO
+
+        aws_connect describe-contact-flow-module \
+            --instance-id $instance_id_b \
+            --contact-flow-module-id $module_id_b \
+            > $TEMPFILE || error $LINENO
+        cat $TEMPFILE |
+        jq -r '.ContactFlowModule.Content' > "$instance_alias_dir_b/$module_json"
+    done
+    test $? -eq 0 || error
+fi
+
+
+############################################################
+#
+# Contact Flows Update
+#
 
 cat <<EOD
 

--- a/bin/connect_diff
+++ b/bin/connect_diff
@@ -7,7 +7,7 @@
 #   connect_save on instance A and B.
 #
 
-VERSION=1.3
+VERSION=1.3.1
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD

--- a/bin/connect_diff
+++ b/bin/connect_diff
@@ -7,7 +7,7 @@
 #   connect_save on instance A and B.
 #
 
-VERSION=1.2.2
+VERSION=1.3
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD
@@ -139,6 +139,7 @@ fi
 
 routing_profile_to_ignore="Basic Routing Profile"
 flow_template=$helper/flow_template.json
+module_template=$helper/module_template.json
 
 cat <<EOD
 Instance Alias A: $instance_alias_a (in directory "$instance_alias_dir_a")
@@ -398,8 +399,8 @@ cat > $flow_template <<EOD
         "ActionMetadata": {
             "e093fb75-2263-4594-875e-2d8e9974595f": {
                 "position": {
-                    "x": 223,
-                    "y": 76
+                    "x": 120,
+                    "y": 20
                 }
             }
         }
@@ -412,6 +413,40 @@ cat > $flow_template <<EOD
             "Transitions": {}
         }
     ]
+}
+EOD
+
+cat > $module_template <<EOD
+{
+  "Version": "2019-10-30",
+  "StartAction": "13f850a8-4882-4b78-ac83-508273b6a3d6",
+  "Metadata": {
+    "entryPointPosition": {
+      "x": 20,
+      "y": 20
+    },
+    "ActionMetadata": {
+      "13f850a8-4882-4b78-ac83-508273b6a3d6": {
+        "position": {
+          "x": 120,
+          "y": 20
+        }
+      }
+    }
+  },
+  "Actions": [
+    {
+      "Parameters": {},
+      "Identifier": "13f850a8-4882-4b78-ac83-508273b6a3d6",
+      "Type": "EndFlowModuleExecution",
+      "Transitions": {}
+    }
+  ],
+  "Settings": {
+    "InputParameters": [],
+    "OutputParameters": [],
+    "Transitions": []
+  }
 }
 EOD
 

--- a/bin/connect_diff
+++ b/bin/connect_diff
@@ -7,7 +7,7 @@
 #   connect_save on instance A and B.
 #
 
-VERSION=1.3.1
+VERSION=1.3.2
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD
@@ -137,7 +137,7 @@ if [ -d $helper ]; then
     fi
 fi
 
-routing_profile_to_ignore="Basic Routing Profile"
+# routing_profile_to_ignore="Basic Routing Profile"
 flow_template=$helper/flow_template.json
 module_template=$helper/module_template.json
 
@@ -316,9 +316,9 @@ echo Checking Routing Profiles ...
 jq -r ".Id + \" \" + .Name" "$instance_alias_dir_a/routings.json" |
 dos2unix |
 while read routing_id_a routing_name; do
-    if [ "$routing_name" == "$routing_profile_to_ignore" ]; then
-        continue
-    fi
+    # if [ "$routing_name" == "$routing_profile_to_ignore" ]; then
+    #     continue
+    # fi
     routing_name_encoded=$(path_encode "$routing_name")
     # routing_id_b=$(jq -r "select(.Name == \"${routing_name//\"/\\\"}\") | .Id" "$instance_alias_dir_b/routings.json")
     routing_id_b=$(sed -e's/\\"/%22/g' "$instance_alias_dir_b/routings.json" | jq -r "select(.Name == \"${routing_name//\"/%22}\") | .Id" | dos2unix)

--- a/bin/connect_save
+++ b/bin/connect_save
@@ -5,7 +5,7 @@
 # Get a list of components of an Amazon Connect instance
 #
 
-VERSION=1.3.1
+VERSION=1.3.2
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD

--- a/bin/connect_save
+++ b/bin/connect_save
@@ -5,7 +5,7 @@
 # Get a list of components of an Amazon Connect instance
 #
 
-VERSION=1.2.2
+VERSION=1.3
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD

--- a/bin/connect_save
+++ b/bin/connect_save
@@ -391,8 +391,7 @@ while read module_id module_name; do
             echo "$module_name: Contact flow module not published"
             # Let error decide if continue or not
             error $LINENO "$module_name" "$instance_alias_dir/modules.json"
-        fi
-        if [ -s $TEMPCF ]; then
+        else
             cat $TEMPCF |
             jq -r '.ContactFlowModule.Content' > "$instance_alias_dir/module_$module_name_encoded.json"
         fi
@@ -431,11 +430,18 @@ while read flow_id flow_name; do
     aws_connect describe-contact-flow \
         --instance-id $instance_id \
         --contact-flow-id $flow_id > $TEMPCF \
-        || error $LINENO "$flow_name" "$instance_alias_dir/flows.json"
+        2> /dev/null
+    #     || error $LINENO "$flow_name" "$instance_alias_dir/flows.json"
+    # AWS CLI seems not returning error for unpublished
+    # Need to check for an empty $TEMPCF
     flow_name_encoded=$(path_encode "$flow_name")
     if [ -s $TEMPCF ]; then
         cat $TEMPCF |
         jq -r '.ContactFlow.Content' > "$instance_alias_dir/flow_$flow_name_encoded.json"
+    else
+        echo
+        echo "$flow_name: Contact flow not published"
+        error $LINENO "$flow_name" "$instance_alias_dir/flows.json"
     fi
 done
 test $? -eq 0 || error

--- a/bin/connect_save
+++ b/bin/connect_save
@@ -5,7 +5,7 @@
 # Get a list of components of an Amazon Connect instance
 #
 
-VERSION=1.3
+VERSION=1.3.1
 SCRIPT_VERSION="$(basename $0) $VERSION"
 
 USAGE=$(cat <<EOD
@@ -293,6 +293,7 @@ test $? -eq 0 || error
 aws_connect list-queues \
     --instance-id $instance_id \
     --max-items $maxitems \
+    --queue-types "STANDARD" \
     > $TEMPFILE || error $LINENO
 
 cat $TEMPFILE |


### PR DESCRIPTION
- Version 1.3.2
  - Fix QueueName select in RoutingProfileQueueConfigSummaryList
  - Remove routing_profile_to_ignore from connect_diff
  - Explicit with `.` in `jq -s '.'` (instead of just `jq -s`) in connect_copy
